### PR TITLE
fix an issue in which link targets were truncated by one character

### DIFF
--- a/src/nlinkfs.c
+++ b/src/nlinkfs.c
@@ -270,12 +270,12 @@ static int nlinkfs_readlink(const char *path, char *buf, size_t size)
 		if (size < 0) {
 			return -EFAULT;
 		} else {
-			if (llen > size) {
+			if (llen >= size) {
 				strncpy(buf, link->str, size);
 				buf[size-1] = '\0';
 			} else {
 				strcpy(buf, link->str);
-				buf[llen-1] = '\0';
+				buf[llen] = '\0';
 			}
 			return 0;
 		}


### PR DESCRIPTION
On my system running Ubuntu 22.04.2 with libfuse2 v2.9.9, the current default branch of nlinkfs (d332903a303e064cc8960e1cdafe54b0a7d15aae) has an issue in which all symlink targets are truncated by one character, and thus are broken links. 

The most recent commit that did not have this issue was 2f78fc262398b869b1f40dc1549d33e63eaac2a5 so it appears that it was introduced in e292ba8f67eb0c5b2b303ddd1fe5c72e908461d7. 

The cause of the issue appears to be some fencepost issues regarding the size of the string and the buffer to be filled by readlink, and the result is that when the link target string fits within the provided buffer, it ends up being truncated despite the fact that it would fit. 

In the block:
https://github.com/rene/nlinkfs/blob/d332903a303e064cc8960e1cdafe54b0a7d15aae/src/nlinkfs.c#L273-L279

I believe `llen` represents the length of the link target string without the terminating null, while `size` represents the size of the buffer to be filled including the terminating null. 

Thus, my proposed fix is:
 -  change the first arm of the conditional from `llen > size` to `llen >= size` because when `llen` and `size` are equal, this means there is not actually enough space in the buffer to accomodate all of the link target string, and it will thus be truncated in this case (as is the documented behavior of `readlink`)
  - fix the second arm of the conditional (which now represents `llen < size` and which means there _is_ enough space in the buffer for the entirety of the link target plus its null terminator) so that it adds the null terminator at `buf[llen]` (the position right after the last character in the string of length `llen`) instead of `buf[llen-1]` (which truncates the last character off the string). 
  
  